### PR TITLE
Fix ESLint SARIF workflow

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -32,13 +32,14 @@ jobs:
 
       - name: Install
         run: |
-          yarn install
-          yarn add @microsoft/eslint-formatter-sarif@2.1.7
+          yarn install --immutable
+          yarn add --dev --no-lockfile @microsoft/eslint-formatter-sarif@2.1.7
 
       - name: Run ESLint
-        run: yarn lint
-          --format @microsoft/eslint-formatter-sarif
-          --output-file eslint-results.sarif
+        run: |
+          yarn lint \
+            --format node_modules/@microsoft/eslint-formatter-sarif/sarif.js \
+            --output-file eslint-results.sarif
         continue-on-error: true
 
       - name: Upload analysis results to GitHub

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install
         run: |
           yarn install --immutable
-          yarn add --dev --no-lockfile @microsoft/eslint-formatter-sarif@2.1.7
+          yarn add --dev @microsoft/eslint-formatter-sarif@2.1.7
 
       - name: Run ESLint
         run: |


### PR DESCRIPTION
## Summary
- ensure ESLint results are generated as SARIF
- install formatter in CI in dev mode
- use formatter's path for the run command

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68436a2aea648326b2fe420c123f8053

## Summary by Sourcery

Fix the ESLint GitHub Actions workflow to generate SARIF results by installing and referencing the SARIF formatter correctly and enforcing immutable dependency installs

CI:
- Use yarn install --immutable in the ESLint workflow for consistent CI installs
- Install @microsoft/eslint-formatter-sarif as a dev dependency without updating the lockfile
- Run ESLint with the SARIF formatter via its node_modules path to output eslint-results.sarif

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated dependency installation and ESLint workflow steps for improved consistency and reliability in automated checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->